### PR TITLE
Build out MWE - serve index.html and then attempt to download from it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 headless-downloads/**
 chrome-dir/**
 devils_gambit.rb
+*.swp

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # headless-chrome-fail-case
 
-An MWE to show the limitations of headless chrome when downloading a PDF from a new tab link.
+An MWE to show the limitations of headless chrome when downloading a PDF from a new tab link. The options and preferences used to configure chrome were taken from [this chromium thread](https://bugs.chromium.org/p/chromium/issues/detail?id=696481#c89). These comments are old, but it's the only one to seem to have gotten things working with capybara.
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# headless-chrome-fail-case
+
+An MWE to show the limitations of headless chrome when downloading a PDF from a new tab link.
+
+### Installation
+
+Install the required gems and drivers.
+
+### Running the example
+
+#### Start an http server in this directory
+I'm a python person, so I use:
+- `python3 -m http.server`
+
+Visit [http://localhost:8000](http://localhost:8000) and try out both links. Both should point to our [sample PDF](http://www.pdf995.com/samples/pdf.pdf), one in a new tab and one not.
+
+#### Test download with headless chrome
+
+Run the ruby code that uses headless chrome / selenium to download this:
+- `ruby download_pdf.rb`
+
+By default this will attempt to download the new tab PDF. It won't fail, but there won't be any files listed in the DOWNLOAD_PATH at the end of the script.
+
+#### Test normal (no new tab) download
+
+Edit `download_pdf.rb` to find `id: "normal_link"` on line 9, then run `ruby download_pdf.rb` again. This time the DOWNLOAD_PATH should have a PDF file in it, which you can go in and open.
+
+#### Test new tab download with headed chrome
+Restore `download_pdf.rb` to its original state, so it's looking for `id: "newtab_link"`. Then open scrapppy.rb and comment out line 18, where we're specifying that chrome run in `--headless` mode. Save and then run `ruby download_pdf.rb` again. Chrome will start in headed mode, then successfully download the new tab PDF.
+
+### System info and versions
+- capybara (2.18.0)
+- selenium-webdriver (3.141.0)
+- ChromeDriver 2.44.609545
+
+
+

--- a/download_pdf.rb
+++ b/download_pdf.rb
@@ -5,8 +5,8 @@ session = Capybara::Session.new(:headless)
 
 list_files
 
-session.visit "http://www.gutenberg.org/ebooks/6168"
-link_node = session.all('table.files a.link').detect{|n|n.text == "EPUB (with images)"}
+session.visit "http://localhost:8000/"
+link_node = session.find_link(id: "newtab_link")
 puts "Clicking link"
 link_node.click
 puts "Waiting a few seconds"

--- a/index.html
+++ b/index.html
@@ -1,0 +1,2 @@
+<a href="http://www.pdf995.com/samples/pdf.pdf" id="newtab_link" target="_blank">New tab link- download fails</a><br>
+<a href="http://www.pdf995.com/samples/pdf.pdf" id="normal_link">Regular link- download succeeds</a>

--- a/scrapppy.rb
+++ b/scrapppy.rb
@@ -7,66 +7,40 @@ require 'pry'
 
 DOWNLOAD_PATH = Pathname.new('headless-downloads')
 USER_DIR = Pathname.new('chrome-dir')
-SWITCHES = [
-  '--window-size=1280,1024',
-  '--disable-bundled-ppapi-flash',
-  '--disable-extensions',
-  '--disable-java',
-  '--disable-plugins',
-  '--disable-plugins-discovery',
-  '--ignore-certificate-errors',
-  '--headless',
-  '--disable-gpu',
-  '--incognito',
-  '--new-window',
-  '--no-sandbox',
-  '--disable-dev-shm-usage',
-  "--user-data-dir=#{USER_DIR}"
-]
-def chrome_options
-  Selenium::WebDriver::Chrome::Options.new.tap do |options|
-    options.add_preference('pdfjs.disabled', true)
-    options.add_preference('plugins.always_open_pdf_externally', true)
-    options.add_preference(
-      'plugins.plugins_disabled',
-      [
-        'Chrome PDF Viewer',
-        'Adobe Flash Player',
-        'Widevine Content Decryption Module',
-        'Native Client'
-      ]
-    )
-
-    options.add_preference(
-      :download,
-      directory_upgrade: true,
-      prompt_for_download: false,
-      default_directory: DOWNLOAD_PATH
-    )
-    options.add_preference(:browser, set_download_behavior: { behavior: 'allow' })
-
-    SWITCHES.each do |switch|
-      options.add_argument(switch)
-    end
-  end
-end
 
 def configure
   FileUtils.rm_rf(DOWNLOAD_PATH)
 
-  Capybara::Driver::Base.class_eval { def status_code; 'unknown'.freeze; end }
-  Capybara.default_max_wait_time = 10
-
   Capybara.register_driver :headless do |app|
-    Capybara::Selenium::Driver.new(app, browser: :chrome, options: chrome_options).tap do |driver|
-      driver.browser.download_path = DOWNLOAD_PATH
-    end
+    options = Selenium::WebDriver::Chrome::Options.new
+  
+    options.add_argument('--headless')
+    options.add_argument('--no-sandbox')
+    options.add_argument('--disable-gpu')
+    options.add_argument('--disable-popup-blocking')
+    options.add_argument('--window-size=1366,768')
+  
+    options.add_preference(:download, directory_upgrade: true,
+                                      prompt_for_download: false,
+                                      default_directory: DOWNLOAD_PATH)
+  
+    options.add_preference(:browser, set_download_behavior: { behavior: 'allow' })
+  
+    driver = Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+  
+    bridge = driver.browser.send(:bridge)
+  
+    path = '/session/:session_id/chromium/send_command'
+    path[':session_id'] = bridge.session_id
+  
+    bridge.http.call(:post, path, cmd: 'Page.setDownloadBehavior',
+                                  params: {
+                                    behavior: 'allow',
+                                    downloadPath: DOWNLOAD_PATH
+                                  })
+  
+    driver
   end
-
-  Capybara.default_driver = :headless
-  Capybara.javascript_driver = :headless
-  Capybara.current_driver = :headless
-  Selenium::WebDriver.logger.level = :warn
 end
 
 def list_files


### PR DESCRIPTION
A few things to make this more reproducible- 

- Serve our own page so we can compare different new tab vs direct downloads
- Use chrome options from this (previously) [working example](https://bugs.chromium.org/p/chromium/issues/detail?id=696481#c89).

Unfortunately still no path forward - downloads work when they're direct, but fail when they open a new tab. Hopefully someone on SO can provide some guidance; either that or I'll try dockerizing to run with specific versions of chromium / capybara / selenium.